### PR TITLE
[docs] Generate linting docs from source

### DIFF
--- a/docs/_writing-tests/lint-tool.md
+++ b/docs/_writing-tests/lint-tool.md
@@ -22,6 +22,10 @@ those cases you can [whitelist test files](#updating-the-whiteslist)
 to suppress the errors. In all other cases, follow the instructions
 below to fix all errors reported.
 
+```eval_rst
+.. wpt-lint-rules:: tools.lint.rules
+```
+
 * **CONSOLE**: Test-file line has a `console.*(...)` call; **fix**: remove
   the `console.*(...)` call (and in some cases, consider adding an
   `assert_*` of some kind in place of it).
@@ -55,9 +59,6 @@ below to fix all errors reported.
   element whose `content` attribute has a malformed value; **fix**: ensure
   the value of the `content` attribute starts with `?` or `#` or is empty.
 
-* **MISSING-LINK**: CSS test file is missing a link to a spec. **fix**: Ensure that there is a `<link rel="help" href="[url]">` for the spec.
-  * Note: `MISSING-LINK` is designed to ensure that the CSS build tool can find the tests. Note that the CSS build system is primarily used by [test.csswg.org/](http://test.csswg.org/), which doesn't use `wptserve`, so `*.any.js` and similar tests won't work there; stick with the `.html` equivalent.
-
 * **MISSING-TESTHARNESSREPORT**: Test file is missing an instance of
   `<script src='/resources/testharnessreport.js'>`; **fix**: ensure each
   test file contains `<script src='/resources/testharnessreport.js'>`.
@@ -86,9 +87,6 @@ below to fix all errors reported.
 
 * **SET TIMEOUT**: Test-file line has `setTimeout(...)` call; **fix**:
   replace all `setTimeout(...)` calls with `step_timeout(...)` calls.
-
-* **TRAILING WHITESPACE**: Test-file line has trailing whitespace; **fix**:
-  remove trailing whitespace from all lines in the file.
 
 * **VARIANT-MISSING**: Test file with a `<meta name='variant'...>` element
   that's missing a `content` attribute; **fix**: add a `content` attribute

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-#import os
-#import sys
-#sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 
@@ -72,11 +72,13 @@ exclude_patterns = [
     '_venv'
 ]
 
+from docs.wpt_lint_rules import WPTLintRules
 # Enable inline reStructured Text within Markdown-formatted files
 # https://recommonmark.readthedocs.io/en/latest/auto_structify.html
 from recommonmark.transform import AutoStructify
 def setup(app):
     app.add_transform(AutoStructify)
+    app.add_directive('wpt-lint-rules', WPTLintRules)
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None

--- a/docs/wpt_lint_rules.py
+++ b/docs/wpt_lint_rules.py
@@ -1,0 +1,72 @@
+from docutils.parsers.rst import Directive, nodes
+from docutils.utils import new_document
+from recommonmark.parser import CommonMarkParser
+import importlib
+import textwrap
+
+class WPTLintRules(Directive):
+    """A docutils directive to generate documentation for the
+    web-platform-test-test's linting tool from its source code. Requires a
+    single argument: a Python module specifier for a file which declares
+    linting rules."""
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 0
+    _md_parser = CommonMarkParser()
+
+    @staticmethod
+    def _parse_markdown(markdown):
+        WPTLintRules._md_parser.parse(markdown, new_document("<string>"))
+        return WPTLintRules._md_parser.document.children[0]
+
+    @property
+    def module_specifier(self):
+        return self.arguments[0]
+
+    def _get_rules(self):
+        try:
+            module = importlib.import_module(self.module_specifier)
+        except ImportError:
+            raise ImportError(
+                """wpt-lint-rules: unable to resolve the module at "{}".""".format(self.module_specifier)
+            )
+
+        for binding_name, value in module.__dict__.iteritems():
+            description = getattr(value, "description", None)
+            name = getattr(value, "name", None)
+            to_fix = getattr(value, "to_fix", None)
+
+            if description is None:
+                continue
+
+            yield {
+                "name": name,
+                "description": textwrap.dedent(description),
+                "to_fix": textwrap.dedent(to_fix)
+            }
+
+
+    def run(self):
+        definition_list = nodes.definition_list()
+
+        for rule in self._get_rules():
+            item = nodes.definition_list_item()
+            definition = nodes.definition()
+            term = nodes.term()
+            item += term
+            item += definition
+            definition_list += item
+
+            term += nodes.literal(text=rule["name"])
+            definition += nodes.paragraph(text=rule["description"])
+
+            if rule["to_fix"]:
+                definition += nodes.strong(text="To fix:")
+                definition += WPTLintRules._parse_markdown(rule["to_fix"])
+
+        if len(definition_list.children) == 0:
+            raise Exception(
+                """wpt-lint-rules: no linting rules found at "{}".""".format(self.module_specifier)
+            )
+
+        return [definition_list]

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -1,0 +1,47 @@
+import os
+import re
+
+class Rule(object):
+    name = None
+    description = None
+    to_fix = None
+
+    @classmethod
+    def error(cls, path, line_no):
+        return [(cls.name, cls.description, path, line_no)]
+
+
+class MissingLink(Rule):
+    name = "MISSING-LINK"
+    description = "Testcase file must have a link to a spec"
+    to_fix = """
+        Ensure that there is a `<link rel="help" href="[url]">` for the spec.
+        `MISSING-LINK` is designed to ensure that the CSS build tool can find
+        the tests. Note that the CSS build system is primarily used by
+        [test.csswg.org/](http://test.csswg.org/), which doesn't use
+        `wptserve`, so `*.any.js` and similar tests won't work there; stick
+        with the `.html` equivalent.
+    """
+
+
+class Regexp(Rule):
+    pattern = None
+    file_extensions = None
+    _re = None
+
+    def __init__(self):
+        self._re = re.compile(self.pattern)
+
+    def applies(self, path):
+        return (self.file_extensions is None or
+                os.path.splitext(path)[1] in self.file_extensions)
+
+    def search(self, line):
+        return self._re.search(line)
+
+
+class TrailingWhitespaceRegexp(Regexp):
+    name = "TRAILING WHITESPACE"
+    description = "Whitespace at EOL"
+    pattern = b"[ \t\f\v]$"
+    to_fix = """Remove trailing whitespace from all lines in the file."""


### PR DESCRIPTION
When new rules have been added to WPT's "lint" tool, the corresponding
documentation has not always been updated [1] [2] [3]. Automatically
generating documentation from source code helps avoid this state and the
confusion it can cause contributors.

Introduce a pattern for defining linting rules. Rely on the new
structure during documentation generation to automatically create a
listing of all available linting rules.

The new structure centralizes information about the rules (name,
description, and instructions for correcting infractions). The process
honors the existing convention of Markdown within descriptions.

Although the Sphinx documentation generator includes a built-in
extension for generating documentation from Python source code, the
output of that extension is designed to document Python primitives such
as functions and classes. Such a format is inappropriate for this case
because the users of the linting tool do not interact with the internals
in this way. Define a custom docutils directive to tailor the
documentation to the needs of its audience.

[1] https://github.com/web-platform-tests/wpt/issues/5299
[2] https://github.com/web-platform-tests/wpt/issues/10501
[3] https://github.com/web-platform-tests/wpt/issues/11479

---

This is intended to resolve gh-4.

@zcorpan @jgraham @gsnedders @marcoscaceres  I'm demoing this with two rules,
but I'll be happy to migrate the rest of the rules to this format if the
general solution looks good to you. Here's a screen shot of the rendered
output:

![2019-03-29-linting-docs](https://user-images.githubusercontent.com/677252/55253387-90ec7e00-522b-11e9-93c3-73f8bf177ee2.png)

What do you think?